### PR TITLE
Fix the empty communityDetailView #48

### DIFF
--- a/BTCMap/AppState.swift
+++ b/BTCMap/AppState.swift
@@ -20,6 +20,7 @@ final class MapState: ObservableObject {
     @Published var bounds: Bounds?
     @Published var style: MapStyle = .topo
     @Published var visibleObjects: MapVisibleObjects = .elements
+    @Published var selectedCommunity: API.Area?
 
     init(centerCoordinate: CLLocationCoordinate2D? = nil, bounds: Bounds? = nil) {
         self.centerCoordinate = centerCoordinate

--- a/BTCMap/Home.swift
+++ b/BTCMap/Home.swift
@@ -26,9 +26,9 @@ struct Home: View {
     
     // MARK: - CommunityDetail
     @State private var showCommunityDetail = false
-    @State private var selectedCommunity: API.Area?
+
     private func communityDetailView() -> CommunityDetailView? {
-        if let community = selectedCommunity {
+        if let community = appState.mapState.selectedCommunity {
             let viewModel = CommunityDetailViewModel(areaWithDistance: AreaWithDistance(area: community))
             return CommunityDetailView(communityDetailViewModel: viewModel)
         }
@@ -40,8 +40,7 @@ struct Home: View {
         mapVCWrapper.mapViewController.mapState = appState.mapState
         mapVCWrapper.mapViewController.elementsRepo = elementsRepository
         mapVCWrapper.mapViewController.areasRepo = areasRepository
-        mapVCWrapper.mapViewController.onCommunityTapped = { community in
-            self.selectedCommunity = community
+        mapVCWrapper.mapViewController.onCommunityTapped = { _ in
             self.showCommunityDetail.toggle()
         }
     }
@@ -108,9 +107,13 @@ struct Home: View {
             
             // Community Detail sheet
             .sheet(isPresented: $showCommunityDetail, content: {
+                // TODO: - understand why this is called 5 times on each $showCommunityDetail value changes
                 if let communityDetailView = communityDetailView() {
-                    NavigationView {                        
+                    NavigationView {
                         communityDetailView
+                    }
+                    .onDisappear() {
+                        appState.mapState.selectedCommunity = nil
                     }
                 }
             })

--- a/BTCMap/MapViewController.swift
+++ b/BTCMap/MapViewController.swift
@@ -216,6 +216,7 @@ class MapViewController: UIViewController, MKMapViewDelegate, UISheetPresentatio
     }
     
     private func onTapPolygon(_ communityPolygon: CommunityPolygon) {
+        mapState.selectedCommunity = communityPolygon.community
         onCommunityTapped?(communityPolygon.community)
     }
     


### PR DESCRIPTION
Store the selectedCommunity in a MapState property, probably not the best practice, but working better than the previous selectedCommunity property that gets nil sometimes